### PR TITLE
Fixed typo

### DIFF
--- a/HC_SR4_Demo_Arduino/HC_SR4_Demo_Arduino/Ultrasonic.cpp
+++ b/HC_SR4_Demo_Arduino/HC_SR4_Demo_Arduino/Ultrasonic.cpp
@@ -30,10 +30,10 @@ long Ultrasonic::Timing()
 long Ultrasonic::Ranging(int sys)
 {
   Timing();
-  distacne_cm = duration /29 / 2 ;
+  distance_cm = duration /29 / 2 ;
   distance_inc = duration / 74 / 2;
   if (sys)
-  return distacne_cm;
+  return distance_cm;
   else
   return distance_inc;
 }

--- a/HC_SR4_Demo_Arduino/HC_SR4_Demo_Arduino/Ultrasonic.h
+++ b/HC_SR4_Demo_Arduino/HC_SR4_Demo_Arduino/Ultrasonic.h
@@ -23,7 +23,7 @@ class Ultrasonic
     private:
     int Trig_pin;
     int Echo_pin;
-    long  duration,distacne_cm,distance_inc;
+    long  duration,distance_cm,distance_inc;
     
 };
 


### PR DESCRIPTION
Fixed misspelling `distacne_cm` -> `distance_cm`.
(Sorry, editing on the GitHub web thing made it into separate requests).